### PR TITLE
Add DeriveKey module to META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,8 @@
     "build-depends" : [ "Crypt::Random", "LibraryMake" ],
     "provides" : {
         "Crypt::Argon2" : "lib/Crypt/Argon2.pm6",
-        "Crypt::Argon2::Base" : "lib/Crypt/Argon2/Base.pm6"
+        "Crypt::Argon2::Base" : "lib/Crypt/Argon2/Base.pm6",
+        "Crypt::Argon2::DeriveKey" : "lib/Crypt/Argon2/DeriveKey.pm6"
     },
     "resources" : [ "libraries/argon2" ],
     "source-url" : "git://github.com/skinkade/p6-crypt-argon2.git"


### PR DESCRIPTION
This is needed to make that file available when installed via zef.