### PR TITLE
Strip trailing null bytes from hash

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Crypt::Argon2",
-    "version" : "0.2.1",
+    "version" : "0.2.2",
     "author" : "github:skinkade",
     "description" : "Easy Argon2i password hashing",
     "build-depends" : [ "Crypt::Random", "LibraryMake" ],

--- a/lib/Crypt/Argon2.pm6
+++ b/lib/Crypt/Argon2.pm6
@@ -24,7 +24,7 @@ sub argon2-hash(Str $pwd, :$t_cost = 2, :$m_cost = 1 +< 16,
 
     if $err { die("Hashing failed with error code: "~$err); }
 
-    $encoded.decode;
+    $encoded.decode.subst(/\0+$/, '');
 }
 
 sub argon2-verify($encoded, $pwd) is export {


### PR DESCRIPTION
The buffer into which the hash is filled is the maximum length but
the actual hash may be shorter and the rest of the buffer will remain
filled with null bytes, and, possibly surprisingly, these aren't
removed by .decode.  This doesn't affect the verification against
the hash as back in C-land the first \0 terminates the string.

I found this while trying to save the hash in a database using Red,
where it confused the driver by ending the string at the first \0
before an end quote.