### PR TITLE
Fix resource usage to always get the current .so location

### DIFF
--- a/lib/Crypt/Argon2/Base.pm6
+++ b/lib/Crypt/Argon2/Base.pm6
@@ -6,7 +6,7 @@ unit module Crypt::Argon2::Base;
 
 
 
-constant ARGON2 = %?RESOURCES<libraries/argon2>.Str;
+constant ARGON2 = %?RESOURCES<libraries/argon2>;
 
 
 


### PR DESCRIPTION
By calling .Str on %?RESOURCES, the compilation-time location was installed into the module. When installing with zef, this caused a location in /tmp to be used for this value, and that caused issues with Linux distros that use tmpfs for /tmp. See ugexe/zef#546 for more context.